### PR TITLE
Adiciona As Gems AWS-SDK e Shoryuken

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,10 @@ gem 'ngannotate-rails'
 gem 'bower-rails'
 gem 'responders', '~> 2.0'
 
+# Gerenciamento AWS SQS
+gem 'aws-sdk', '~> 2'
+
+
 group :development do
   gem 'capistrano-rails'
   gem 'web-console', '~> 2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'responders', '~> 2.0'
 
 # Gerenciamento AWS SQS
 gem 'aws-sdk', '~> 2'
-
+gem 'shoryuken'
 
 group :development do
   gem 'capistrano-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,23 @@ GEM
     capistrano-rails (1.2.0)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
+    celluloid (0.17.3)
+      celluloid-essentials
+      celluloid-extras
+      celluloid-fsm
+      celluloid-pool
+      celluloid-supervision
+      timers (>= 4.1.1)
+    celluloid-essentials (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-extras (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-fsm (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-pool (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-supervision (0.20.6)
+      timers (>= 4.1.1)
     chronic (0.10.2)
     clockwork (2.0.0)
       activesupport
@@ -166,6 +183,7 @@ GEM
       rspec (>= 2.99.0, < 4.0)
     haml (4.0.7)
       tilt
+    hitimes (1.2.4)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     httpclient (2.8.2.4)
@@ -335,6 +353,9 @@ GEM
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
     shellany (0.0.1)
+    shoryuken (2.1.1)
+      aws-sdk-core (~> 2)
+      celluloid (~> 0.16)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
     signet (0.7.3)
@@ -362,6 +383,8 @@ GEM
     thor (0.19.4)
     thread_safe (0.3.5)
     tilt (2.0.5)
+    timers (4.1.2)
+      hitimes
     turbolinks (5.0.1)
       turbolinks-source (~> 5)
     turbolinks-source (5.0.0)
@@ -428,6 +451,7 @@ DEPENDENCIES
   rubocop
   sass-rails
   sdoc (~> 0.4.0)
+  shoryuken
   shoulda-matchers (~> 3.1)
   spring
   thin

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,14 @@ GEM
     ast (2.3.0)
     autoprefixer-rails (6.5.3)
       execjs
+    aws-sdk (2.6.39)
+      aws-sdk-resources (= 2.6.39)
+    aws-sdk-core (2.6.39)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.6.39)
+      aws-sdk-core (= 2.6.39)
+    aws-sigv4 (1.0.0)
     bcrypt (3.1.11)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
@@ -166,6 +174,7 @@ GEM
     jbuilder (2.6.1)
       activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
+    jmespath (1.3.1)
     jquery-rails (4.2.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -384,6 +393,7 @@ PLATFORMS
 DEPENDENCIES
   angular-rails-templates
   angularjs-rails
+  aws-sdk (~> 2)
   bcrypt
   better_errors
   bootstrap-sass

--- a/app/workers/aiesec_global_middleware.rb
+++ b/app/workers/aiesec_global_middleware.rb
@@ -1,0 +1,7 @@
+class AiesecGlobalMiddleware
+  def call(worker_instance, queue, sqs_msg, body)
+    puts 'Before Work'
+    yield
+    puts 'After Work'
+  end
+end

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,0 +1,14 @@
+AWS_REGION = ENV['AWS_REGION']
+AWS_ACCESS_KEY_ID = ENV['AWS_ACCESS_KEY_ID']
+AWS_SECRET_ACCESS_KEY = ENV['AWS_SECRET_ACCESS_KEY']
+
+Aws.config.update({
+  region:      AWS_REGION,
+  credentials: Aws::Credentials.new(AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
+})
+
+sqs = Aws::SQS::Client.new(
+  region:      AWS_REGION,
+  credentials: Aws::Credentials.new(AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)
+)
+sqs.create_queue({queue_name: 'default'})

--- a/config/shoryuken.yml
+++ b/config/shoryuken.yml
@@ -1,0 +1,4 @@
+concurrency: 25
+delay: 0
+queues:
+  - [default]


### PR DESCRIPTION
- Adiciona a gem aws-sdk para gerenciamento de acesso à AWS.

- Adiciona a gem shoryuken para gerenciamento do serviço AWS SQS.

Nota¹: Depende da configuração das variáveis de ambiente AWS_REGION, AWS_ACCESS_KEY_ID e AWS_SECRET_ACCESS_KEY, estas últimas referentes as _Security Credentials_ de acesso do usuário a AWS.

Nota²: O nome da fila está como _default_, por hora teremos apenas uma instância de SQS, mudança de nome por questões de organização devem ser aplicadas quando necessário.