### PR TITLE
Slack - Enviar Notificação sobre Nova Mensagem Enviada à Fila

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'google_drive', '>= 2.0'
 gem 'bcrypt'
 gem 'thin'
 gem 'will_paginate', '~> 3.1.0'
+gem 'slack-notifier'
 
 group :doc do
   gem 'sdoc', '~> 0.4.0', group: :doc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -363,6 +363,7 @@ GEM
       faraday (~> 0.9)
       jwt (~> 1.5)
       multi_json (~> 1.10)
+    slack-notifier (1.5.1)
     slop (3.6.0)
     spring (2.0.0)
       activesupport (>= 4.2)
@@ -453,6 +454,7 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   shoryuken
   shoulda-matchers (~> 3.1)
+  slack-notifier
   spring
   thin
   turbolinks

--- a/README.md
+++ b/README.md
@@ -52,6 +52,6 @@
 - AWS_SECRET_ACCESS_KEY
 - AWS_REGION
 
-### Notificações no Slack
+### Slack Notifications
 
 - SLACK_WEBHOOK_URL

--- a/README.md
+++ b/README.md
@@ -51,3 +51,7 @@
 - AWS_ACCESS_KEY_ID
 - AWS_SECRET_ACCESS_KEY
 - AWS_REGION
+
+### Notificações no Slack
+
+- SLACK_WEBHOOK_URL

--- a/app/workers/aiesec_global_worker.rb
+++ b/app/workers/aiesec_global_worker.rb
@@ -9,9 +9,11 @@ class AiesecGlobalWorker
 
   def perform(sqs_msg, body)
     notify_on_slack("Mensagem consumida :envelope_with_arrow:", body)
-byebug
+    Shoryuken.logger.info("Received message: '#{body}'")
+
     if SendToExpa.call(body)
       notify_and_delete_message
+      Shoryuken.logger.info("SendToExpa: '#{body}'")
     end
   end
 

--- a/app/workers/aiesec_global_worker.rb
+++ b/app/workers/aiesec_global_worker.rb
@@ -9,12 +9,10 @@ class AiesecGlobalWorker
 
   def perform(sqs_msg, body)
     notify_on_slack("Mensagem consumida :envelope_with_arrow:", body)
+
     Shoryuken.logger.info("Received message: '#{body}'")
 
-    if SendToExpa.call(body)
-      notify_and_delete_message
-      Shoryuken.logger.info("SendToExpa: '#{body}'")
-    end
+    notify_and_delete_message(sqs_msg, body) if SendToExpa.call(body)
   end
 
   private


### PR DESCRIPTION
O serviço envia notificações sempre que:

- Uma nova mensagem é enviada a fila
- Uma mensagem é consumida
- Uma mensagem é concluida, i.e. seu fluxo foi realizado com sucesso.

Depende da variável de ambiente `SLACK_WEBHOOK_URL` para funcionamento.